### PR TITLE
more suggestions

### DIFF
--- a/src/djot_tokenizer/InlineToken.zig
+++ b/src/djot_tokenizer/InlineToken.zig
@@ -1,8 +1,9 @@
 const std = @import("std");
 const ByteMask = @import("../tokenizer/TextReader.zig").ByteMask;
 const tokenizer = @import("../tokenizer/TextReader.zig");
-const tokens = @import("Token.zig").tokens;
-const minCountError = @import("BlockToken.zig").minCountError;
+const Tokens = @import("Token.zig");
+const opposite = Tokens.opposite;
+const tokens = Tokens.tokens;
 
 pub const DollarByteMask = ByteMask.init("$");
 pub const BacktickByteMask = ByteMask.init("`");
@@ -15,187 +16,192 @@ const RecordStartSymbol = true;
 fn matchInlineToken(reader: tokenizer.TextReader, state: usize, tokenType: tokens) !?usize {
     switch (tokenType) {
         tokens.RawFormatInline => {
-            return reader.token(state, [_]u8{ '{', '=' });
+            return reader.token(state, "{=");
         },
-        tokens.RawFormatInline ^ 1 => {
-            return reader.token(state, [_]u8{'}'});
+        opposite(tokens.RawFormatInline) => {
+            return reader.token(state, "}");
         },
         tokens.VerbatimInline => {
-            const next = reader.maskRepeat(state, DollarByteMask, 1) orelse return minCountError;
+            const next = reader.maskRepeat(state, DollarByteMask, 1) orelse return error.MinCountError;
             if ((next - state) > 2) {
                 return null;
             }
             return reader.maskRepeat(next, BacktickByteMask, 1);
         },
-        tokens.VerbatimInline ^ 1 => {
+        opposite(tokens.VerbatimInline) => {
             return reader.maskRepeat(state, BacktickByteMask, 1);
         },
         tokens.ImageSpanInline => {
-            return reader.token(state, [_]u8{ '!', '[' });
+            return reader.token(state, "![");
         },
         tokens.SpanInline => {
-            return reader.token(state, [_]u8{'['});
+            return reader.token(state, "[");
         },
-        tokens.SpanInline ^ 1, tokens.ImageSpanInline ^ 1 => {
-            return reader.token(state, [_]u8{']'});
+        opposite(tokens.SpanInline), opposite(tokens.ImageSpanInline) => {
+            return reader.token(state, "]");
         },
         tokens.LinkUrlInline => {
-            return reader.token(state, [_]u8{'('});
+            return reader.token(state, "(");
         },
-        tokens.LinkUrlInline ^ 1 => {
-            return reader.token(state, [_]u8{')'});
+        opposite(tokens.LinkUrlInline) => {
+            return reader.token(state, ")");
         },
         tokens.LinkReferenceInline => {
-            return reader.token(state, [_]u8{'['});
+            return reader.token(state, "[");
         },
-        tokens.LinkReferenceInline ^ 1 => {
-            return reader.token(state, [_]u8{']'});
+        opposite(tokens.LinkReferenceInline) => {
+            return reader.token(state, "]");
         },
         tokens.AutolinkInline => {
-            return reader.token(state, [_]u8{'<'});
+            return reader.token(state, "<");
         },
-        tokens.AutolinkInline ^ 1 => {
-            return reader.token(state, [_]u8{'>'});
+        opposite(tokens.AutolinkInline) => {
+            return reader.token(state, ">");
         },
         tokens.EscapedSymbolInline => {
-            const next = reader.token(state, [_]u8{'\\'}) orelse return null;
+            var next = reader.token(state, "\\") orelse return null;
             if (reader.isEmpty(next)) {
                 return null;
             }
             if (reader.maskRepeat(next, tokenizer.SpaceByteMask, 0)) |asciiNext| {
                 return asciiNext;
             }
-            next = reader.maskRepeat(next, tokenizer.SpaceByteMask, 0) orelse return minCountError;
-            return reader.token(next, [_]u8{'\n'});
+            next = reader.maskRepeat(next, tokenizer.SpaceByteMask, 0) orelse return error.MinCountError;
+            return reader.token(next, "\n");
         },
         tokens.EmphasisInline => {
-            if (reader.token(state, [_]u8{ '{', '_' })) |next| {
+            if (reader.token(state, "{_")) |next| {
                 return next;
             }
-            const next = reader.token(state, [_]u8{'_'});
-            if (next and !reader.hasMask(next, tokenizer.SpaceNewLineByteMask)) {
+            const next = reader.token(state, "_");
+            if (next != null and !reader.hasMask(next.?, tokenizer.SpaceNewLineByteMask)) {
                 return next;
             }
             return null;
         },
-        tokens.EmphasisInline ^ 1 => {
-            if (reader.token(state, [_]u8{ '_', '}' })) |next| {
+        opposite(tokens.EmphasisInline) => {
+            if (reader.token(state, "_}")) |next| {
                 return next;
             }
-            const next = reader.token(state, [_]u8{'_'});
-            if (next and state > 0 and !reader.hasMask(state - 1, tokenizer.SpaceNewLineByteMask)) {
+            const next = reader.token(state, "_");
+            if (next != null and state > 0 and !reader.hasMask(state - 1, tokenizer.SpaceNewLineByteMask)) {
                 return next;
             }
             return null;
         },
         tokens.StrongInline => {
-            if (reader.token(state, [_]u8{ '{', '*' })) |next| {
+            if (reader.token(state, "{*")) |next| {
                 return next;
             }
-            const next = reader.token(state, [_]u8{'*'});
-            if (next and !reader.hasMask(next, tokenizer.SpaceNewLineByteMask)) {
+            const next = reader.token(state, "*");
+            if (next != null and !reader.hasMask(next.?, tokenizer.SpaceNewLineByteMask)) {
                 return next;
             }
             return null;
         },
-        tokens.StrongInline ^ 1 => {
-            if (reader.token(state, [_]u8{ '*', '}' })) |next| {
+        opposite(tokens.StrongInline) => {
+            if (reader.token(state, "*}")) |next| {
                 return next;
             }
-            const next = reader.token(state, [_]u8{'*'});
-            if (next and state > 0 and !reader.hasMask(state - 1, tokenizer.SpaceNewLineByteMask)) {
+            const next = reader.token(state, "*");
+            if (next != null and state > 0 and !reader.hasMask(state - 1, tokenizer.SpaceNewLineByteMask)) {
                 return next;
             }
             return null;
         },
         tokens.HighlightedInline => {
-            return reader.token(state, [_]u8{ '{', '=' });
+            return reader.token(state, "{=");
         },
-        tokens.HighlightedInline ^ 1 => {
-            return reader.token(state, [_]u8{ '=', '}' });
+        opposite(tokens.HighlightedInline) => {
+            return reader.token(state, "=}");
         },
         tokens.SubscriptInline => {
-            if (reader.token(state, [_]u8{ '{', '~' })) |next| {
+            if (reader.token(state, "{~")) |next| {
                 return next;
             }
-            return reader.token(state, [_]u8{'~'});
+            return reader.token(state, "~");
         },
-        tokens.SubscriptInline ^ 1 => {
-            if (reader.token(state, [_]u8{ '~', '}' })) |next| {
+        opposite(tokens.SubscriptInline) => {
+            if (reader.token(state, "~}")) |next| {
                 return next;
             }
-            return reader.token(state, [_]u8{'~'});
+            return reader.token(state, "~");
         },
         tokens.SuperscriptInline => {
-            if (reader.token(state, [_]u8{ '{', '^' })) |next| {
+            if (reader.token(state, "{^")) |next| {
                 return next;
             }
-            return reader.token(state, [_]u8{'^'});
+            return reader.token(state, "^");
         },
-        tokens.SuperscriptInline ^ 1 => {
-            if (reader.token(state, [_]u8{ '^', '}' })) |next| {
+        opposite(tokens.SuperscriptInline) => {
+            if (reader.token(state, "^}")) |next| {
                 return next;
             }
-            return reader.token(state, [_]u8{'^'});
+            return reader.token(state, "^");
         },
         tokens.InsertInline => {
-            return reader.token(state, [_]u8{ '{', '+' });
+            return reader.token(state, "{+");
         },
-        tokens.InsertInline ^ 1 => {
-            return reader.token(state, [_]u8{ '+', '}' });
+        opposite(tokens.InsertInline) => {
+            return reader.token(state, "+}");
         },
         tokens.DeleteInline => {
-            return reader.token(state, [_]u8{ '{', '-' });
+            return reader.token(state, "{-");
         },
-        tokens.DeleteInline ^ 1 => {
-            return reader.token(state, [_]u8{ '-', '}' });
+        opposite(tokens.DeleteInline) => {
+            return reader.token(state, "-}");
         },
         tokens.FootnoteReferenceInline => {
-            return reader.token(state, [_]u8{ '[', '^' });
+            return reader.token(state, "[^");
         },
-        tokens.FootnoteReferenceInline ^ 1 => {
-            return reader.token(state, [_]u8{']'});
+        opposite(tokens.FootnoteReferenceInline) => {
+            return reader.token(state, "]");
         },
         tokens.SymbolsInline => {
-            const next = reader.token(state, [_]u8{':'}) orelse return null;
+            const next = reader.token(state, ":") orelse return null;
             const word = reader.maskRepeat(next, AlphaNumericSymbolByteMask, 0);
-            if (word and reader.hasToken(word.?, [_]u8{':'})) {
+            if (word != null and reader.hasToken(word.?, ":")) {
                 return next;
             }
             return null;
         },
-        tokens.SymbolsInline ^ 1 => {
-            return reader.token(state, [_]u8{':'});
+        opposite(tokens.SymbolsInline) => {
+            return reader.token(state, ":");
         },
         tokens.PipeTableSeparator => {
-            const next = reader.token(state, [_]u8{'|'}) orelse return null;
+            const next = reader.token(state, "|") orelse return null;
             return reader.maskRepeat(next, tokenizer.SpaceByteMask, 0);
         },
-        tokens.PipeTableSeparator ^ 1 => {
-            const s = reader.maskRepeat(state, tokenizer.SpaceByteMask, 0) orelse return minCountError;
-            if (reader.token(s, [_]u8{'|'})) |next| {
-                if (reader.emptyOrWhiteSpace(next)) {
-                    return next;
+        opposite(tokens.PipeTableSeparator) => {
+            const s = reader.maskRepeat(state, tokenizer.SpaceByteMask, 0) orelse return error.MinCountError;
+            if (reader.token(s, "|")) |next| {
+                if (reader.emptyOrWhiteSpace(next)) |end| {
+                    return end;
                 }
                 return s;
             }
             return null;
         },
         tokens.SmartSymbolInline => {
-            if (reader.token(state, [_]u8{'{'})) |next| {
+            if (reader.token(state, "{")) |next| {
                 return next;
             }
-            if (reader.token(state, SmartSymbolByteMask)) |next| {
-                if (reader.hasToken(next, [_]u8{'}'})) {
+            if (reader.mask(state, SmartSymbolByteMask)) |next| {
+                if (reader.hasToken(next, "}")) {
                     return next + 1;
                 }
                 return next;
             }
-            if (reader.token(state, [3]u8{ '.', '.', '.' })) |next| {
+            if (reader.token(state, "...")) |next| {
                 return next;
             }
             return reader.byteRepeat(state, '-', 2);
         },
         else => unreachable,
     }
+}
+
+test "matchInlineToken" {
+    const reader = tokenizer.TextReader.init("*hi*");
+    try std.testing.expectEqual(1, matchInlineToken(reader, 0, tokens.StrongInline));
 }

--- a/src/djot_tokenizer/Token.zig
+++ b/src/djot_tokenizer/Token.zig
@@ -14,4 +14,62 @@ pub const blockKeys = enum {
     ReferenceKey,
 };
 
-pub const tokens = enum { None, Ignore, DocumentBlock, HeadingBlock, QuoteBlock, ListItemBlock, CodeBlock, DivBlock, PipeTableBlock, ReferenceDefBlock, FootnoteDefBlock, ParagraphBlock, ThematicBreakToken, PipeTableCaptionBlock, Attribute, Padding, RawFormatInline, VerbatimInline, ImageSpanInline, LinkUrlInline, LinkReferenceInline, AutolinkInline, EscapedSymbolInline, EmphasisInline, StrongInline, HighlightedInline, SubscriptInline, SuperscriptInline, InsertInline, DeleteInline, FootnoteReferenceInline, SpanInline, SymbolsInline, PipeTableSeparator, SmartSymbolInline };
+fn tokenEnum(names: anytype) type {
+    var fields: [2 + names.len * 2]std.builtin.Type.EnumField = undefined;
+    fields[0] = .{ .name = "None", .value = 0 };
+    fields[1] = .{ .name = "Ignore", .value = 1 };
+    inline for (names, 0..) |name, i| {
+        fields[2 + i * 2] = .{ .name = @tagName(name), .value = 2 * (i + 2) + 1 };
+        fields[2 + i * 2 + 1] = .{ .name = @tagName(name) ++ "Close", .value = 2 * (i + 2) };
+    }
+    return @Type(.{ .Enum = .{
+        .tag_type = u64,
+        .fields = &fields,
+        .decls = &[_]std.builtin.Type.Declaration{},
+        .is_exhaustive = true,
+    } });
+}
+
+pub fn opposite(e: anytype) @TypeOf(e) {
+    return @enumFromInt(@intFromEnum(e) ^ 1);
+}
+
+pub const tokens = tokenEnum(.{
+    .DocumentBlock,
+    .HeadingBlock,
+    .QuoteBlock,
+    .ListItemBlock,
+    .CodeBlock,
+    .DivBlock,
+    .PipeTableBlock,
+    .ReferenceDefBlock,
+    .FootnoteDefBlock,
+    .ParagraphBlock,
+    .ThematicBreakToken,
+    .PipeTableCaptionBlock,
+    .Attribute,
+    .Padding,
+    .RawFormatInline,
+    .VerbatimInline,
+    .ImageSpanInline,
+    .LinkUrlInline,
+    .LinkReferenceInline,
+    .AutolinkInline,
+    .EscapedSymbolInline,
+    .EmphasisInline,
+    .StrongInline,
+    .HighlightedInline,
+    .SubscriptInline,
+    .SuperscriptInline,
+    .InsertInline,
+    .DeleteInline,
+    .FootnoteReferenceInline,
+    .SpanInline,
+    .SymbolsInline,
+    .PipeTableSeparator,
+    .SmartSymbolInline,
+});
+
+test "token" {
+    try std.testing.expectEqual(tokens.SpanInline, opposite(opposite(tokens.SpanInline)));
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -10,6 +10,19 @@ const LineTokenizer = @import("tokenizer/LineTokenizer.zig").LineTokenizer;
 const ByteMask = @import("tokenizer/TextReader.zig").ByteMask;
 const ByteMaskUnion = @import("tokenizer/TextReader.zig").Union;
 const TextReader = @import("tokenizer/TextReader.zig").TextReader;
+pub const DjotBlockToken = @import("djot_tokenizer/BlockToken.zig");
+pub const DjotInlineToken = @import("djot_tokenizer/InlineToken.zig");
+pub const DjotToken = @import("djot_tokenizer/Token.zig");
+
+test "ref" {
+    std.testing.refAllDeclsRecursive(DjotAttributes);
+    std.testing.refAllDeclsRecursive(DjotBlockToken);
+    std.testing.refAllDeclsRecursive(DjotInlineToken);
+    std.testing.refAllDeclsRecursive(DjotToken);
+    std.testing.refAllDeclsRecursive(Attributes);
+    std.testing.refAllDeclsRecursive(LineTokenizer);
+    std.testing.refAllDeclsRecursive(TextReader);
+}
 
 // in Zig you can define tests right inside the source code files (they will be stripped from final binary automatically by compiler)
 test "Attributes" {


### PR DESCRIPTION
- Referenced several source roots from "tests.zig" in order to be able to write test right next to the implementation
- Fixed tokens enum - in Zig it's harder to make the trick with open / close tokens as enums are strongly typed. So, I generated enum definition in comptime and added `opposite` function for emulation of `^ 1` operation
- Replaced `[_]u8{...}` with simple Zig strings